### PR TITLE
Component info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /node_modules
 
 # build
-/lib
+#/lib
 
 # log
 *.log

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,42 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = function (_ref) {
+  var t = _ref.types;
+
+  var defaultPrefix = 'data-qa';
+  var defaultDebugProperty = 'qa';
+
+  var prefix = void 0;
+  var componentAttr = void 0;
+
+  var visitor = {
+    Program: function Program(path, state) {
+      if (state.opts.prefix) {
+        prefix = 'data-' + state.opts.prefix;
+      } else {
+        prefix = defaultPrefix;
+      }
+      componentAttr = prefix + '-component';
+    },
+    JSXOpeningElement: function JSXOpeningElement(path, state) {
+      var attributes = path.container.openingElement.attributes;
+      var newAttributes = [];
+
+      if (state.file && state.file.opts) {
+        var source = state.file.opts.sourceFileName.replace(/\/index.jsx$/, '').replace(/.jsx$/, '');
+
+        newAttributes.push(t.jSXAttribute(t.jSXIdentifier(componentAttr), t.jSXExpressionContainer(t.logicalExpression('&&', t.memberExpression(t.identifier('__DEBUG'), t.identifier(defaultDebugProperty)), t.stringLiteral(source)))));
+      }
+
+      attributes.push.apply(attributes, newAttributes);
+    }
+  };
+
+  return {
+    visitor: visitor
+  };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,10 @@
 
 export default function({types: t}) {
   const defaultPrefix = 'data-qa';
+  const defaultDebugProperty = 'qa';
+
   let prefix;
-  let filenameAttr;
-  let nodeNameAttr;
+  let componentAttr;
 
   const visitor = {
     Program(path, state) {
@@ -13,28 +14,26 @@ export default function({types: t}) {
       } else {
         prefix = defaultPrefix;
       }
-      filenameAttr = `${prefix}-file`;
-      nodeNameAttr = `${prefix}-node`;
+      componentAttr = `${prefix}-component`;
     },
     JSXOpeningElement(path, state) {
       const attributes = path.container.openingElement.attributes;
-
       const newAttributes = [];
 
-      if (path.container && path.container.openingElement &&
-        path.container.openingElement.name &&
-        path.container.openingElement.name.name) {
-        newAttributes.push(t.jSXAttribute(
-          t.jSXIdentifier(nodeNameAttr),
-          t.stringLiteral(path.container.openingElement.name.name))
-        );
-      }
+      if (state.file && state.file.opts) {
+        const source = state.file.opts.sourceFileName.replace(/\/index.jsx$/, '').replace(/.jsx$/, '')
 
-      if (state.file && state.file.opts && state.file.opts.basename) {
         newAttributes.push(t.jSXAttribute(
-          t.jSXIdentifier(filenameAttr),
-          t.stringLiteral(state.file.opts.basename))
-        );
+          t.jSXIdentifier(componentAttr),
+          t.jSXExpressionContainer(t.logicalExpression(
+            '&&',
+            t.memberExpression(
+              t.identifier('__DEBUG'),
+              t.identifier(defaultDebugProperty),
+            ),
+            t.stringLiteral(source)
+          ))
+        ));
       }
 
       attributes.push(...newAttributes);


### PR DESCRIPTION
We need to add extra attribute to DOM nodes. For this reason, we decided to take the original repo as a base to tweak the code to cover our needs. With this code, QA will be able to set `window.qa_debug` to `true` to enable the main functionality of this code and expose the component path and the have a nice locator to base their tests.